### PR TITLE
feat: include archived items in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.6 - 2025-08-09
+### Added
+- Global search can include archived items via "Include Archived" toggle.
+
 ## 0.0.5 - 2025-08-09
 ### Added
 - In-memory Fuse.js search index with file system watching and query API.

--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Upgrading
 
-See [CHANGELOG.md](CHANGELOG.md) for release notes. Upgrades are data-compatible across versions; backup your `data/` folder and replace application files to move from 0.0.4 to 0.0.5.
+See [CHANGELOG.md](CHANGELOG.md) for release notes. Upgrades are data-compatible across versions; backup your `data/` folder and replace application files to move from 0.0.5 to 0.0.6.

--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -15,4 +15,14 @@ describe('Search API', () => {
     expect(res.status).toBe(200);
     expect(res.body.results.length).toBeGreaterThan(0);
   });
+
+  it('optionally includes archived content', async () => {
+    await request(app).post('/api/file/archive/notes/archived.md').send({ content: 'archived note' });
+    let res = await request(app).get('/api/search').query({ q: 'archived' });
+    expect(res.status).toBe(200);
+    expect(res.body.results.find(r => r.path.includes('archived.md'))).toBeUndefined();
+    res = await request(app).get('/api/search').query({ q: 'archived', includeArchived: '1' });
+    expect(res.status).toBe(200);
+    expect(res.body.results.find(r => r.path === 'archive/notes/archived.md')).toBeDefined();
+  });
 });

--- a/build.js
+++ b/build.js
@@ -40,7 +40,7 @@ async function buildWindows() {
         });
         
         console.log('✓ Windows build completed successfully!');
-        console.log('Installer saved to: dist/CapsuleOS-0.0.5-Windows-Setup.exe');
+        console.log('Installer saved to: dist/CapsuleOS-0.0.6-Windows-Setup.exe');
         
     } catch (error) {
         console.error('Build failed:', error);

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,7 +13,7 @@ files:
 
 extraMetadata:
   main: index.js
-  version: 0.0.5
+  version: 0.0.6
 
 win:
   target:

--- a/index.js
+++ b/index.js
@@ -55,14 +55,17 @@ async function initializeDataFolders() {
 }
 
 // API Routes
-function searchData(query) {
-    return searchIndexer.query(query).map(item => ({ path: item.itemId }));
+function searchData(query, options = {}) {
+    return searchIndexer
+        .query(query, options)
+        .map(item => ({ path: item.itemId }));
 }
 
 app.get('/api/search', (req, res) => {
     try {
         const q = req.query.q || '';
-        const results = q ? searchData(q) : [];
+        const includeArchived = req.query.includeArchived === '1' || req.query.includeArchived === 'true';
+        const results = q ? searchData(q, { includeArchived }) : [];
         res.json({ results });
     } catch (error) {
         console.error('Search error:', error);
@@ -244,7 +247,7 @@ async function startServer() {
         searchIndexer.buildIndex();
 
         const server = app.listen(PORT, '0.0.0.0', () => {
-            console.log(`CapsuleOS v0.0.5 Server running on http://0.0.0.0:${PORT}`);
+            console.log(`CapsuleOS v0.0.6 Server running on http://0.0.0.0:${PORT}`);
             console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
         });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capsuleos",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capsuleos",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capsuleos",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Local-first cognitive operating system for personal productivity",
   "main": "index.js",
   "scripts": {

--- a/src/app.js
+++ b/src/app.js
@@ -935,6 +935,8 @@ function showSearchModal() {
     const input = document.getElementById('search-input');
     input.value = '';
     document.getElementById('search-results').innerHTML = '';
+    const includeArchived = document.getElementById('search-include-archived');
+    if (includeArchived) includeArchived.checked = false;
     input.focus();
 }
 
@@ -944,7 +946,9 @@ function hideSearchModal() {
 
 async function performSearch(query) {
     try {
-        const data = await searchIndex.query(query);
+        const includeArchived = document.getElementById('search-include-archived')?.checked;
+        const opts = includeArchived ? { includeArchived: '1' } : {};
+        const data = await searchIndex.query(query, opts);
         const resultsEl = document.getElementById('search-results');
         const resultsHtml = data.results.map(r => `<li><a href="#">${r.path}</a></li>`).join('');
         resultsEl.innerHTML = DOMPurify.sanitize(resultsHtml);

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CapsuleOS v0.0.5</title>
+    <title>CapsuleOS v0.0.6</title>
     <style>
         :root {
             --bg-primary: #0f0f0f;
@@ -348,7 +348,7 @@
         <nav class="sidebar">
             <div class="logo">
                 <h1>CapsuleOS</h1>
-                <p>v0.0.5</p>
+                <p>v0.0.6</p>
             </div>
             <div class="nav-menu">
                 <button class="nav-item active" data-module="notes">📝 Notes</button>
@@ -510,6 +510,9 @@
     <div id="search-modal" class="modal">
         <div class="modal-content">
             <input type="text" id="search-input" class="form-input" placeholder="Search..." />
+            <label style="display:block; margin-top:8px; font-size:12px;">
+                <input type="checkbox" id="search-include-archived" /> Include Archived
+            </label>
             <ul id="search-results" style="margin-top:10px; list-style:none; padding:0;"></ul>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- allow search API to include archived items
- add UI toggle for including archived files
- document archived search toggle and bump to v0.0.6

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893a5107fa88332b1eea64306d8f6f4