### PR TITLE
feat: support versioned search results

### DIFF
--- a/__tests__/search.test.js
+++ b/__tests__/search.test.js
@@ -25,4 +25,22 @@ describe('Search API', () => {
     expect(res.status).toBe(200);
     expect(res.body.results.find(r => r.path === 'archive/notes/archived.md')).toBeDefined();
   });
+
+  it('returns only latest version by default', async () => {
+    await request(app).post('/api/file/notes/versioned.md').send({ content: 'v1 content' });
+    await request(app).post('/api/file/notes/versioned.v2.md').send({ content: 'v2 content' });
+    const res = await request(app).get('/api/search').query({ q: 'content' });
+    expect(res.status).toBe(200);
+    const paths = res.body.results.map(r => r.path);
+    expect(paths).toContain('notes/versioned.v2.md');
+    expect(paths).not.toContain('notes/versioned.md');
+  });
+
+  it('can include all versions when requested', async () => {
+    const res = await request(app).get('/api/search').query({ q: 'content', versions: 'all' });
+    expect(res.status).toBe(200);
+    const paths = res.body.results.map(r => r.path);
+    expect(paths).toContain('notes/versioned.md');
+    expect(paths).toContain('notes/versioned.v2.md');
+  });
 });

--- a/__tests__/versionParser.test.js
+++ b/__tests__/versionParser.test.js
@@ -1,0 +1,18 @@
+const { parseFilename, buildFilename } = require('../src/lib/version');
+
+describe('Version parser utility', () => {
+  test('parses filename without version as v1', () => {
+    const res = parseFilename('notes/test.md');
+    expect(res).toEqual({ base: 'test', version: 1, ext: '.md' });
+  });
+
+  test('parses filename with version', () => {
+    const res = parseFilename('notes/test.v3.md');
+    expect(res).toEqual({ base: 'test', version: 3, ext: '.md' });
+  });
+
+  test('builds filename correctly', () => {
+    expect(buildFilename('test', 1, '.md')).toBe('test.md');
+    expect(buildFilename('test', 2, '.md')).toBe('test.v2.md');
+  });
+});

--- a/index.js
+++ b/index.js
@@ -58,14 +58,15 @@ async function initializeDataFolders() {
 function searchData(query, options = {}) {
     return searchIndexer
         .query(query, options)
-        .map(item => ({ path: item.itemId }));
+        .map(item => ({ path: item.itemId, version: item.version }));
 }
 
 app.get('/api/search', (req, res) => {
     try {
         const q = req.query.q || '';
         const includeArchived = req.query.includeArchived === '1' || req.query.includeArchived === 'true';
-        const results = q ? searchData(q, { includeArchived }) : [];
+        const versions = req.query.versions || 'latest';
+        const results = q ? searchData(q, { includeArchived, versions }) : [];
         res.json({ results });
     } catch (error) {
         console.error('Search error:', error);

--- a/src/lib/version.js
+++ b/src/lib/version.js
@@ -1,0 +1,21 @@
+const path = require('path');
+
+function parseFilename(filePath) {
+  const ext = path.extname(filePath);
+  const name = path.basename(filePath, ext);
+  const match = name.match(/^(.*)\.v(\d+)$/);
+  if (match) {
+    return { base: match[1], version: parseInt(match[2], 10), ext };
+  }
+  return { base: name, version: 1, ext };
+}
+
+function buildFilename(base, version, ext) {
+  if (!ext.startsWith('.')) ext = `.${ext}`;
+  if (version && version > 1) {
+    return `${base}.v${version}${ext}`;
+  }
+  return `${base}${ext}`;
+}
+
+module.exports = { parseFilename, buildFilename };


### PR DESCRIPTION
## Summary
- add reusable version filename parser
- index and filter latest capsule versions in search
- expose versions in search API with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68945fbd95e883328f31a1ffc3b493bd